### PR TITLE
fixed annotation sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ ServiceCallback constraint and ServiceCallbackValidator enables to validate a va
 
 ```
 /**
- * @ServiceCallback(service="mydomain.specification.email_limit",method="isSatisfiedBy",
-    message="email limit error.", errorPath="emailMax", groups={"user_check"})
+ * @ServiceCallback(service="mydomain.specification.email_limit", method="isSatisfiedBy",
+    message="email limit error.", errorPath="emailMax")
  */
 class User
 {


### PR DESCRIPTION
`groups` というオプションはまだ実装されていないでしょうか。
- 動かない

``` php
/**
 * @ServiceCallback(service="mydomain.specification.email_limit",method="isSatisfiedBy",
    message="email limit error.", errorPath="emailMax", groups={"user_check"})
 */
```
- 動く

``` php
/**
 * @ServiceCallback(service="mydomain.specification.email_limit", method="isSatisfiedBy",
    message="email limit error.", errorPath="emailMax")
 */
```
